### PR TITLE
Fix nil pointer dereference

### DIFF
--- a/pkg/retriever/api.go
+++ b/pkg/retriever/api.go
@@ -94,13 +94,20 @@ func (c *APIRetriever) getSpotInstances() {
 		}
 
 		for _, request := range resp.SpotInstanceRequests {
+			var instanceID string
+			if request.InstanceId == nil {
+				instanceID = ""
+			} else {
+				instanceID = *request.InstanceId
+			}
+
 			labels := prometheus.Labels{
 				"account":           service.Account,
 				"region":            service.Region,
 				"state":             *request.State,
 				"code":              *request.Status.Code,
 				"instance_type":     *request.LaunchSpecification.InstanceType,
-				"instance_id":       *request.InstanceId,
+				"instance_id":       instanceID,
 				"availability_zone": *request.LaunchedAvailabilityZone,
 			}
 			spotRequestItems = append(spotRequestItems, labels)


### PR DESCRIPTION
this is a race condition problem where `*request.InstanceId` is not yet set, when we try to access it.
@rebuy-de/prp-cost-exporter 