### PR TITLE
Show actual count of CPU cores

### DIFF
--- a/pkg/retriever/api.go
+++ b/pkg/retriever/api.go
@@ -76,7 +76,7 @@ func (c *APIRetriever) getCores() {
 		for _, reservation := range resp2.Reservations {
 			for _, instance := range reservation.Instances {
 				if *instance.State.Name == "running" {
-					totalCoreCount = totalCoreCount + *instance.CpuOptions.CoreCount
+					totalCoreCount += *instance.CpuOptions.CoreCount * *instance.CpuOptions.ThreadsPerCore
 				}
 			}
 		}


### PR DESCRIPTION
By default it was showing 2 cores for a 4 vCore instance because it has `ThreadsPerCore` as another parameter. Let's multiply them so we get the actual core count.